### PR TITLE
앱 내 링크 썸네일 클릭 시 새 창으로 열리지 않는 에러 해결

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,15 +1,25 @@
 import React from 'react';
-import { SafeAreaView, StatusBar } from 'react-native';
+import { Linking, SafeAreaView, StatusBar } from 'react-native';
 import { WebView } from 'react-native-webview';
 
 import theme from '~/styles/theme';
 
 export default function HomeScreen() {
+  const uri = 'https://app.ygtang.kr/';
   return (
     <>
       <StatusBar barStyle="default" />
       <SafeAreaView style={{ flex: 1, backgroundColor: theme.color.background }}>
-        <WebView source={{ uri: 'https://app.ygtang.kr' }} />
+        <WebView
+          source={{ uri }}
+          onNavigationStateChange={event => {
+            if (!event.url.includes(uri)) {
+              Linking.openURL(event.url);
+              return false;
+            }
+            return true;
+          }}
+        />
       </SafeAreaView>
     </>
   );


### PR DESCRIPTION
# ⛳️작업 내용
<!-- 작업한 사항을 간략하게 적어주세요 -->
사이트 도메인을 포함하지 않은 경우 사용자의 디폴트 브라우저로 이동해서 링크로 이동합니다.

```tsx
import React from 'react';
import { Linking, SafeAreaView, StatusBar } from 'react-native';
import { WebView } from 'react-native-webview';

import theme from '~/styles/theme';

export default function HomeScreen() {
  const uri = 'https://app.ygtang.kr/';
  return (
    <>
      <StatusBar barStyle="default" />
      <SafeAreaView style={{ flex: 1, backgroundColor: theme.color.background }}>
        <WebView
          source={{ uri }}
          onNavigationStateChange={event => {
            if (!event.url.includes(uri)) {
              Linking.openURL(event.url);
              return false;
            }
            return true;
          }}
        />
      </SafeAreaView>
    </>
  );
}

```
# 📸스크린샷
<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

# ⚡️사용 방법
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

# 📎레퍼런스
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
https://stackoverflow.com/questions/35531679/react-native-open-links-in-browser