### PR TITLE
onShouldStartLoadWithRequest ios일 경우, 명시적으로 클릭했을때만 외부링크 열기

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Linking, SafeAreaView, StatusBar } from 'react-native';
+import { Linking, Platform, SafeAreaView, StatusBar } from 'react-native';
 import { WebView, WebViewNavigation } from 'react-native-webview';
 
 import theme from '~/styles/theme';
@@ -8,12 +8,18 @@ const uri = 'https://app.ygtang.kr/';
 
 export default function HomeScreen() {
   const handleExternalLinks = (event: WebViewNavigation) => {
-    if (!event.url.startsWith(uri)) {
-      Linking.openURL(event.url);
+    const isExternalLink =
+      Platform.OS === 'ios' ? event.navigationType === 'click' : true;
+    if (isExternalLink) {
+      Linking.canOpenURL(event.url).then(supported => {
+        if (supported) {
+          Linking.openURL(event.url);
+        }
+      });
       return false;
     }
     return true;
-  };
+  }
 
   return (
     <>


### PR DESCRIPTION
# ⛳️작업 내용
- onShouldStartLoadWithRequest가 추가되면서 발생한 이슈를 해결했습니다.
  - ios일 경우, webview URL 로드하면서 자동으로 호출되어 발생하는 에러였습니다.
  - 그래서, ios일 경우, click이벤트가 있을 경우로 명시적으로 open되도록 변경했습니다.
  
- 안드로이드는 알아서 잘한다고 합니다!
<!-- 작업한 사항을 간략하게 적어주세요 -->

# 📸스크린샷
### ERROR
<img width="687" alt="스크린샷 2022-06-01 오전 12 33 08" src="https://user-images.githubusercontent.com/59507527/171218541-bfa34c0d-4702-430e-9e6c-b9b467b6606a.png">

### 지금
<img width="475" alt="스크린샷 2022-06-01 오전 1 01 30" src="https://user-images.githubusercontent.com/59507527/171222462-2b59da82-a00f-41b8-8e29-9aa45c1ed65f.png">

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->
# ⚡️사용 방법
**Platform ios인지 확인하고 event파악하면 됩니다!** 
```ts
 const handleExternalLinks = (event: WebViewNavigation) => {
  const isExternalLink =
    Platform.OS === 'ios' ? event.navigationType === 'click' : true;
  if (isExternalLink) {
    Linking.canOpenURL(event.url).then(supported => {
      if (supported) {
        Linking.openURL(event.url);
      }
    });
    return false;
  }
  return true;
}
```
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

# 📎레퍼런스
https://stackoverflow.com/questions/60493866/onshouldstartloadwithrequest-automatically-calling-in-ios-react-native-on-loadin
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
