### PR TITLE
IOS - 카메라 및 앨범 접근 권한 추가

### DIFF
--- a/ios/ygt/Info.plist
+++ b/ios/ygt/Info.plist
@@ -62,6 +62,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>직접 촬영한 이미지를 첨부하기 위해 $(PRODUCT_NAME) 앱이 카메라에 접근합니다.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>이미지를 첨부하기 위해 $(PRODUCT_NAME) 앱이 앨범에 접근합니다.</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>


### PR DESCRIPTION
# ⛳️작업 내용
- 카메라 및 앨범 접근 권한을 추가하였습니다.
```xml
<key>NSCameraUsageDescription</key>
<string>직접 촬영한 이미지를 첨부하기 위해 $(PRODUCT_NAME) 앱이 카메라에 접근합니다.</string>
<key>NSPhotoLibraryAddUsageDescription</key>
<string>이미지를 첨부하기 위해 $(PRODUCT_NAME) 앱이 앨범에 접근합니다.</string>
<key>UIViewControllerBasedStatusBarAppearance</key>
```
<!-- 작업한 사항을 간략하게 적어주세요 -->

# 📸스크린샷
<!-- 스크린샷으로 작업한 사항을 보여주세요 -->
<img width="826" alt="image" src="https://user-images.githubusercontent.com/59507527/172000124-7d677b09-94b0-4a21-95d8-dfeb85956810.png">

